### PR TITLE
README example for state components

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ state is active. `StateComponent` isn't `Default`, so insert it through a
 `template` closure:
 
 ```rust
+use bevy_gearbox::prelude::*;
+
+#[state_component]
+#[derive(Component)]
+struct Walking;
+
 #Walking template(|_| Ok(StateComponent(Walking)))
 // The `Walking` component appears on the machine root while this state is active.
 ```

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ use bevy_gearbox::prelude::*;
 #[derive(Component)]
 struct Walking;
 
+// ...
+
 #Walking template(|_| Ok(StateComponent(Walking)))
 // The `Walking` component appears on the machine root while this state is active.
 ```


### PR DESCRIPTION
so, absent context, I didn't know that state components had to be annotated with `#[state_component]`